### PR TITLE
Bg hide classroom content

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,6 +1,6 @@
 class WelcomeController < ApplicationController
   def index
-    current_user ? @tutorials = Tutorial.all : @tutorials = Tutorial.public
+    current_user ? @tutorials = Tutorial.all : @tutorials = Tutorial.public_tutorials
     p = params
     if p[:tag]
       @tutorials = @tutorials.tagged_with(p[:tag]).paginate(page: p[:page],

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,11 +1,13 @@
 class WelcomeController < ApplicationController
   def index
+    current_user ? @tutorials = Tutorial.all : @tutorials = Tutorial.public
     p = params
     if p[:tag]
-      @tutorials = Tutorial.tagged_with(p[:tag]).paginate(page: p[:page],
+      @tutorials = @tutorials.tagged_with(p[:tag]).paginate(page: p[:page],
                                                           per_page: 5)
     else
-      @tutorials = Tutorial.all.paginate(page: p[:page], per_page: 5)
+      @tutorials = @tutorials.paginate(page: p[:page], per_page: 5)
     end
   end
+
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -24,4 +24,7 @@ class Tutorial < ApplicationRecord
     end
   end
 
+  def self.public
+    where(classroom: false)
+  end
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -24,7 +24,7 @@ class Tutorial < ApplicationRecord
     end
   end
 
-  def self.public
+  def self.public_tutorials
     where(classroom: false)
   end
 end

--- a/spec/features/vistors/visitor_cannot_see_classroom_videos_spec.rb
+++ b/spec/features/vistors/visitor_cannot_see_classroom_videos_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'visitor sees a video show' do
+  it 'vistor clicks on a tutorial title from the home page' do
+    tutorial1 = create(:tutorial)
+    tutorial1.update!(classroom: true)
+    video = create(:video, tutorial_id: tutorial1.id)
+    
+    tutorial2 = create(:tutorial)
+    video = create(:video, tutorial_id: tutorial2.id)
+
+    visit '/'
+
+    expect(page).to_not have_content(tutorial1.title)
+
+  end
+end

--- a/spec/features/vistors/visitor_cannot_see_classroom_videos_spec.rb
+++ b/spec/features/vistors/visitor_cannot_see_classroom_videos_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'visitor sees a video show' do
   it 'vistor clicks on a tutorial title from the home page' do
     tutorial1 = create(:tutorial)
-    tutorial1.update!(classroom: true)
+    tutorial1.update(classroom: true)
     video = create(:video, tutorial_id: tutorial1.id)
     
     tutorial2 = create(:tutorial)


### PR DESCRIPTION
# Hide Tutorials marked as "classroom"
Closes: #24 
### Added
- Test that visitors do not see tutorials where `classroom` column is set to `true`
- Tutorial.public class method that returns only tutorials where `classroom` is set to `false`
### Updated
- Welcome controller to check for `current_user` and sends the authorized tutorials to the view