### PR TITLE
Tutorial destroys videos

### DIFF
--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,5 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial
+  has_many :videos, -> { order(position: :ASC) }, inverse_of: :tutorial, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Tutorial, type: :model do
+  
+  describe 'Destroying tutorial' do
+    it 'destroys videos' do
+      tutorial1= create(:tutorial, title: "How to Tie Your Shoes")
+      video1 = create(:video, title: "The Bunny Ears Technique", tutorial: tutorial1)
+      
+      expect(Video.all).to include(video1)
+      
+      tutorial1.destroy
+
+      expect(Video.all).to_not include(video1)
+    end
+  end
 
   describe 'instance methods' do
     it 'import' do


### PR DESCRIPTION
#Destroy Tutorial Destroys Videos
Closes: #21 
### Added
- Test that tutorial videos are destroyed when delete a tutorial from the db
- `dependent: :destroy` to has_many relationship of Tutorial->videos Model