### PR TITLE
Add sad path test for user registration with duplicate email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,9 @@ class UsersController < ApplicationController
   end
 
   def create
-    user = User.create(user_params)
-    if user.save
-      session[:user_id] = user.id
+    @user = User.new(user_params)
+    if @user.save
+      session[:user_id] = @user.id
       redirect_to dashboard_path
     else
       flash[:error] = 'Username already exists'

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -34,28 +34,28 @@ describe 'vister can create an account', :js do
     expect(page).to_not have_content('Sign In')
   end
 
-  # it 'visitor cannot register if username already exists' do
-  #   bob = User.create(email: "bob@example.com", first_name: "Bob", last_name: "Smith", password: "123")
-  #
-  #   email = 'bob@example.com'
-  #   first_name = 'Jim'
-  #   last_name = 'Bob'
-  #   password = 'password'
-  #   password_confirmation = 'password'
-  #
-  #   visit '/'
-  #
-  #   click_on 'Register'
-  #
-  #   fill_in 'user[email]', with: email
-  #   fill_in 'user[first_name]', with: first_name
-  #   fill_in 'user[last_name]', with: last_name
-  #   fill_in 'user[password]', with: password
-  #   fill_in 'user[password_confirmation]', with: password
-  #
-  #   click_on'Create Account'
-  #
-  #   expect(page).to have_content('Username already exists')
-  #   expect(current_path).to eq(new_user_path)
-  # end
+  it 'visitor cannot register if username already exists' do
+    bob = User.create(email: "bob@example.com", first_name: "Bob", last_name: "Smith", password: "123")
+  
+    email = 'bob@example.com'
+    first_name = 'Jim'
+    last_name = 'Bob'
+    password = 'password'
+    password_confirmation = 'password'
+  
+    visit '/'
+  
+    click_on 'Register'
+  
+    fill_in 'user[email]', with: email
+    fill_in 'user[first_name]', with: first_name
+    fill_in 'user[last_name]', with: last_name
+    fill_in 'user[password]', with: password
+    fill_in 'user[password_confirmation]', with: password
+  
+    click_on'Create Account'
+  
+    expect(page).to have_content('Username already exists')
+   
+  end
 end


### PR DESCRIPTION
# Sad paths
Closes: #53 
 - Uncommented Visitor test where new user has duplicate email as another user
  - Modified user_controller to render sad path